### PR TITLE
Added dependacy for mysql-chef-gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,13 @@
 # limitations under the License.
 #
 
+case node["platform"]
+when "debian", "ubuntu"
+  package 'ruby1.9.1-dev'
+when "redhat", "centos", "fedora"
+
+end
+
 mysql_chef_gem 'default' do
   action :install
 end


### PR DESCRIPTION
It seems that you need ruby191-dev, or mkmf, installed otherwise
this will bomb out.

The error this resolves is this:

``` ruby
        /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from extconf.rb:5:in `<main>'
```
