### PR TITLE
Revert "Added dependacy for mysql-chef-gem"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,13 +17,6 @@
 # limitations under the License.
 #
 
-case node["platform"]
-when "debian", "ubuntu"
-  package 'ruby1.9.1-dev'
-when "redhat", "centos", "fedora"
-
-end
-
 mysql_chef_gem 'default' do
   action :install
 end


### PR DESCRIPTION
This reverts commit 84f2f2fad79a882bcf6d97d69caf0f78099f52ed from https://github.com/opscode-cookbooks/mysql-chef_gem/pull/3.

"The chef_gem and gem_package resources are both used to install Ruby gems. For any machine on which the chef-client is installed, there are two instances of Ruby. One is the standard, system-wide instance of Ruby and the other is a dedicated instance that is available only to the chef-client. Use the chef_gem resource to install gems into the instance of Ruby that is dedicated to the chef-client. Use the gem_package resource to install all other gems (i.e. install gems system-wide)."
- https://docs.getchef.com/resource_chef_gem.html

See the discussion under https://github.com/opscode-cookbooks/mysql-chef_gem/pull/3 for more.
