### PR TITLE
add support to handle various mysql vendors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,4 @@
+#
+# default attributes for cookbook
+#
+default['mysql-chef-gem']['vendor'] = 'mysql'

--- a/libraries/provider_mysql_chef_gem.rb
+++ b/libraries/provider_mysql_chef_gem.rb
@@ -14,7 +14,10 @@ class Chef
           end
 
           recipe_eval do
-            run_context.include_recipe 'mysql::client'
+            if new_resource.vendor.nil?
+              new_resource.vendor = 'mysql'
+            end
+            run_context.include_recipe "#{new_resource.vendor}::client"
           end
 
           chef_gem 'mysql' do

--- a/libraries/resource_mysql_chef_gem.rb
+++ b/libraries/resource_mysql_chef_gem.rb
@@ -6,6 +6,7 @@ class Chef
       self.resource_name = :mysql_chef_gem
       actions  :install, :remove
       default_action :install
+      attribute :vendor, :kind_of => String, :default => "mysql"
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,4 +19,5 @@
 
 mysql_chef_gem 'default' do
   action :install
+  vendor node['mysql-chef-gem']['vendor']
 end


### PR DESCRIPTION
Since I use cookbook/database but also I want to use cookbook/percona instead of mysql I had unresolvable conflict in mysql-chef_gem. This small patch add support to 'vendored' version of mysql. Tested with percona and mariadb. I am still no sure how to handle dependency from these cookbooks so I've left as it is.

To use mysql-chef_gem with percona one need to define node attribute e.g in recipe:.

```
node.set['mysql-chef-gem']['vendor'] = 'percona'
```
