### PR TITLE
Update source url in Berksfile to chef.io

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 metadata
 


### PR DESCRIPTION
This fixes the occasional "error retrieving universe from source" during
berks install.
